### PR TITLE
feat: RestControllerAdvice 와 응답용 ErrorMessage 객체 추가함

### DIFF
--- a/src/main/java/com/dnd10/iterview/advice/ExceptionAdvice.java
+++ b/src/main/java/com/dnd10/iterview/advice/ExceptionAdvice.java
@@ -1,0 +1,48 @@
+package com.dnd10.iterview.advice;
+
+import com.dnd10.iterview.advice.exception.ErrorMessage;
+import java.util.Date;
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+  public ErrorMessage methodArgumentNotValidException(HttpServletRequest request, MethodArgumentNotValidException e) {
+    log.error("{}",request.getRequestURL());
+    log.error("{} :: @Valid parameter 에 유효하지 않은 값이 전달되었습니다.",e.getMessage(),e);
+    return getErrorMessage(e.getMessage(), "유효하지 않은 값이 전달되었습니다.");
+  }
+
+  @ExceptionHandler(NullPointerException.class)
+  @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+  public ErrorMessage nullPointerException(HttpServletRequest request, NullPointerException e) {
+    log.error("{}",request.getRequestURL());
+    log.error("{} :: null 인 객체를 참조하였습니다.",e.getMessage(),e);
+    return getErrorMessage(e.getMessage(), "유효하지 않은 값이 전달되었습니다.");
+  }
+  @ExceptionHandler(ArrayIndexOutOfBoundsException.class)
+  @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+  public ErrorMessage arrayIndexOutOfBoundsException(HttpServletRequest request, ArrayIndexOutOfBoundsException e) {
+    log.error("{}",request.getRequestURL());
+    log.error("{} :: index 범위를 벗어나는 참조가 발생했습니다.",e.getMessage());
+    return getErrorMessage(e.getMessage(), "유효하지 않은 값이 전달되었습니다.");
+  }
+
+  private ErrorMessage getErrorMessage(String message, String description) {
+    return ErrorMessage.builder()
+        .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+        .timestamp(new Date())
+        .message(message)
+        .description(description)
+        .build();
+  }
+}

--- a/src/main/java/com/dnd10/iterview/advice/exception/ErrorMessage.java
+++ b/src/main/java/com/dnd10/iterview/advice/exception/ErrorMessage.java
@@ -1,0 +1,21 @@
+package com.dnd10.iterview.advice.exception;
+
+import java.util.Date;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ErrorMessage {
+  private int statusCode;
+  private Date timestamp;
+  private String message;
+  private String description;
+
+  public ErrorMessage(int statusCode, Date timestamp, String message, String description) {
+    this.statusCode = statusCode;
+    this.timestamp = timestamp;
+    this.message = message;
+    this.description = description;
+  }
+}


### PR DESCRIPTION
- 위 기능을 통해 모든 컨트롤러의 예외처리를 위한 try-catch문 작성이 필요없어짐

예외처리가 쉬워집니다. 이제 개발할 때, 필요한 부분에 throw exception만 해주면, 클라이언트에게 오류 메시지를 쉽게 전달할 수 있습니다.

```
  @GetMapping("/tutorials/{id}")
  public ResponseEntity<Tutorial> getTutorialById(@PathVariable("id") long id) {
    Tutorial tutorial = tutorialRepository.findById(id)
        .orElseThrow(() -> new ResourceNotFoundException("Not found Tutorial with id = " + id));

    return new ResponseEntity<>(tutorial, HttpStatus.OK);
  }
```

[참고](https://jeong-pro.tistory.com/195)