### PR TITLE
[#13] 새로운 문제 생성, 문제 조회 구현

### DIFF
--- a/src/main/java/com/dnd10/iterview/config/CurrentUser.java
+++ b/src/main/java/com/dnd10/iterview/config/CurrentUser.java
@@ -8,6 +8,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+@AuthenticationPrincipal//(expression = "#this == 'anonymousUser' ? null : user")
 public @interface CurrentUser {
 }

--- a/src/main/java/com/dnd10/iterview/config/CurrentUser.java
+++ b/src/main/java/com/dnd10/iterview/config/CurrentUser.java
@@ -1,0 +1,13 @@
+package com.dnd10.iterview.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+public @interface CurrentUser {
+}

--- a/src/main/java/com/dnd10/iterview/config/jwt/UserPrincipal.java
+++ b/src/main/java/com/dnd10/iterview/config/jwt/UserPrincipal.java
@@ -1,17 +1,91 @@
 /*package com.dnd10.iterview.config.jwt;
 
+import com.dnd10.iterview.entity.User;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 
 import java.util.List;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @Getter
-public class UserPrincipal extends User {
-    private com.dnd10.iterview.entity.User user;
+public class UserPrincipal implements OAuth2User, UserDetails {
+    private Long id;
+    private String email;
+    private String username;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
 
-    public UserPrincipal(com.dnd10.iterview.entity.User user) {
-        super(user.getEmail(), user.getPassword(), List.of(new SimpleGrantedAuthority("ROLE_USER")));
-        this.user = user;
+    public UserPrincipal(Long id, String email, String username, Collection<? extends GrantedAuthority> authorities) {
+      this.id = id;
+      this.email = email;
+      this.username = username;
+      this.authorities = authorities;
     }
+
+    public static UserPrincipal create(User user){
+      List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+
+      return new UserPrincipal(
+          user.getId(),
+          user.getEmail(),
+          user.getUsername(),
+          authorities
+      );
+    }
+
+    public static UserPrincipal create(User user, Map<String, Object> attributes){
+      UserPrincipal userPrincipal = UserPrincipal.create(user);
+      userPrincipal.setAttributes(attributes);
+
+      return userPrincipal;
+    }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  public String getName() {
+    return String.valueOf(id);
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities(){
+      return authorities;
+  }
+
+  @Override
+  public String getPassword() {
+    return null;
+  }
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, Object> attributes){
+      this.attributes = attributes;
+  }
 }*/

--- a/src/main/java/com/dnd10/iterview/config/jwt/UserPrincipal.java
+++ b/src/main/java/com/dnd10/iterview/config/jwt/UserPrincipal.java
@@ -1,91 +1,16 @@
 /*package com.dnd10.iterview.config.jwt;
 
-import com.dnd10.iterview.entity.User;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 import lombok.Getter;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-
+import org.springframework.security.core.userdetails.User;
 import java.util.List;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @Getter
-public class UserPrincipal implements OAuth2User, UserDetails {
-    private Long id;
-    private String email;
-    private String username;
-    private Collection<? extends GrantedAuthority> authorities;
-    private Map<String, Object> attributes;
+public class UserPrincipal extends User {
+    private com.dnd10.iterview.entity.User user;
 
-    public UserPrincipal(Long id, String email, String username, Collection<? extends GrantedAuthority> authorities) {
-      this.id = id;
-      this.email = email;
-      this.username = username;
-      this.authorities = authorities;
+    public UserPrincipal(com.dnd10.iterview.entity.User user) {
+        super(user.getEmail(), user.getPassword(), List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        this.user = user;
     }
-
-    public static UserPrincipal create(User user){
-      List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
-
-      return new UserPrincipal(
-          user.getId(),
-          user.getEmail(),
-          user.getUsername(),
-          authorities
-      );
-    }
-
-    public static UserPrincipal create(User user, Map<String, Object> attributes){
-      UserPrincipal userPrincipal = UserPrincipal.create(user);
-      userPrincipal.setAttributes(attributes);
-
-      return userPrincipal;
-    }
-
-  @Override
-  public boolean isAccountNonExpired() {
-    return true;
-  }
-
-  @Override
-  public boolean isAccountNonLocked() {
-    return true;
-  }
-
-  @Override
-  public boolean isCredentialsNonExpired() {
-    return true;
-  }
-
-  @Override
-  public boolean isEnabled() {
-    return true;
-  }
-
-  @Override
-  public String getName() {
-    return String.valueOf(id);
-  }
-
-  @Override
-  public Collection<? extends GrantedAuthority> getAuthorities(){
-      return authorities;
-  }
-
-  @Override
-  public String getPassword() {
-    return null;
-  }
-
-  @Override
-  public Map<String, Object> getAttributes() {
-    return attributes;
-  }
-
-  public void setAttributes(Map<String, Object> attributes){
-      this.attributes = attributes;
-  }
 }*/

--- a/src/main/java/com/dnd10/iterview/controller/QuestionController.java
+++ b/src/main/java/com/dnd10/iterview/controller/QuestionController.java
@@ -1,0 +1,10 @@
+package com.dnd10.iterview.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/question")
+public class QuestionController {
+
+}

--- a/src/main/java/com/dnd10/iterview/controller/QuestionController.java
+++ b/src/main/java/com/dnd10/iterview/controller/QuestionController.java
@@ -1,14 +1,18 @@
 package com.dnd10.iterview.controller;
 
+import com.dnd10.iterview.dto.QuestionRequestDto;
 import com.dnd10.iterview.dto.QuestionResponseDto;
 import com.dnd10.iterview.entity.Question;
 import com.dnd10.iterview.repository.QuestionRepository;
 import com.dnd10.iterview.service.QuestionService;
 import io.swagger.annotations.ApiOperation;
 import java.security.Principal;
+import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,6 +30,14 @@ public class QuestionController {
   @GetMapping("/{questionId}")
   public ResponseEntity getQuestion(@PathVariable Long questionId) {
     QuestionResponseDto dto = questionService.getQuestion(questionId);
+
+    return ResponseEntity.ok(dto);
+  }
+
+  @ApiOperation(value = "문제 생성", notes = "<big>새로운 문제</big>를 생성하고 반환한다.")
+  @PostMapping("")
+  public ResponseEntity addQuestion(Principal principal, @RequestBody @Valid QuestionRequestDto requestDto){
+    QuestionResponseDto dto = questionService.addQuestion(principal, requestDto);
 
     return ResponseEntity.ok(dto);
   }

--- a/src/main/java/com/dnd10/iterview/controller/QuestionController.java
+++ b/src/main/java/com/dnd10/iterview/controller/QuestionController.java
@@ -1,10 +1,33 @@
 package com.dnd10.iterview.controller;
 
+import com.dnd10.iterview.dto.QuestionResponseDto;
+import com.dnd10.iterview.entity.Question;
+import com.dnd10.iterview.repository.QuestionRepository;
+import com.dnd10.iterview.service.QuestionService;
+import io.swagger.annotations.ApiOperation;
+import java.security.Principal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/question")
 public class QuestionController {
+
+  QuestionService questionService;
+
+  public QuestionController(QuestionService questionService) {
+    this.questionService = questionService;
+  }
+
+  @ApiOperation(value = "문제 조회", notes = "<big>문제 정보</big>를 반환한다.")
+  @GetMapping("/{questionId}")
+  public ResponseEntity getQuestion(@PathVariable Long questionId) {
+    QuestionResponseDto dto = questionService.getQuestion(questionId);
+
+    return ResponseEntity.ok(dto);
+  }
 
 }

--- a/src/main/java/com/dnd10/iterview/controller/TestController.java
+++ b/src/main/java/com/dnd10/iterview/controller/TestController.java
@@ -1,15 +1,26 @@
 package com.dnd10.iterview.controller;
 
+import com.dnd10.iterview.config.CurrentUser;
+import com.dnd10.iterview.entity.User;
+import com.dnd10.iterview.repository.UserRepository;
+import io.swagger.annotations.ApiOperation;
+import java.security.Principal;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 public class TestController {
+
+  @Autowired
+  UserRepository u;
 
   @GetMapping("/login")
   public ResponseEntity<Object> test(HttpServletRequest request, HttpServletResponse response) {
@@ -27,5 +38,13 @@ public class TestController {
     log.info(response.getHeader("Authorization"));
     log.info(request.getHeader("Authorization"));
     return ResponseEntity.ok(request.getCookies());
+  }
+
+  @ApiOperation(value = "currentuser 테스트", notes = "어노테이션이 잘 되는지 확인하기")
+  @GetMapping("/test")
+  public ResponseEntity getUserProfile(Principal p) {
+
+    User user = u.findUserByEmail(p.getName()).get();
+    return ResponseEntity.ok(user.getUsername());
   }
 }

--- a/src/main/java/com/dnd10/iterview/dto/QuestionRequestDto.java
+++ b/src/main/java/com/dnd10/iterview/dto/QuestionRequestDto.java
@@ -15,6 +15,6 @@ public class QuestionRequestDto {
   @NotBlank
   private String content;
 
-  private Long bookmark_count;
+  private Long bookmark_count; // 필요성?
   private String tags;
 }

--- a/src/main/java/com/dnd10/iterview/dto/QuestionRequestDto.java
+++ b/src/main/java/com/dnd10/iterview/dto/QuestionRequestDto.java
@@ -1,0 +1,17 @@
+package com.dnd10.iterview.dto;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+public class QuestionRequestDto {
+
+  @NotBlank
+  private String content;
+
+  private Long bookmark_count;
+}

--- a/src/main/java/com/dnd10/iterview/dto/QuestionResponseDto.java
+++ b/src/main/java/com/dnd10/iterview/dto/QuestionResponseDto.java
@@ -1,0 +1,23 @@
+package com.dnd10.iterview.dto;
+
+import com.dnd10.iterview.entity.User;
+import java.time.LocalDate;
+import javax.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+public class QuestionResponseDto {
+
+  @NotBlank
+  private String content;
+
+  private Long bookmark_count;
+  private LocalDate create_date;
+
+  private UserDto user;
+
+}

--- a/src/main/java/com/dnd10/iterview/dto/QuestionResponseDto.java
+++ b/src/main/java/com/dnd10/iterview/dto/QuestionResponseDto.java
@@ -1,8 +1,14 @@
 package com.dnd10.iterview.dto;
 
+import com.dnd10.iterview.entity.AuthProvider;
+import com.dnd10.iterview.entity.Question;
+import com.dnd10.iterview.entity.QuestionTag;
 import com.dnd10.iterview.entity.User;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +16,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class QuestionResponseDto {
 
   @NotBlank
@@ -20,4 +27,5 @@ public class QuestionResponseDto {
 
   private UserDto user;
 
+  private List<QuestionTagResponseDto> tagList = new ArrayList<>();
 }

--- a/src/main/java/com/dnd10/iterview/dto/QuestionTagResponseDto.java
+++ b/src/main/java/com/dnd10/iterview/dto/QuestionTagResponseDto.java
@@ -1,6 +1,6 @@
 package com.dnd10.iterview.dto;
 
-import javax.validation.constraints.NotBlank;
+import com.dnd10.iterview.entity.QuestionTag;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,11 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class QuestionRequestDto {
-
-  @NotBlank
-  private String content;
-
-  private Long bookmark_count;
-  private String tags;
+public class QuestionTagResponseDto {
+  // todo: question과 user tag dto를 나눌 필요성이 있는지 생각해보기
+  private String tagTitle;
 }

--- a/src/main/java/com/dnd10/iterview/entity/Question.java
+++ b/src/main/java/com/dnd10/iterview/entity/Question.java
@@ -1,6 +1,8 @@
 package com.dnd10.iterview.entity;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -8,6 +10,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -27,8 +30,6 @@ public class Question {
   @Column(name = "question_id")
   private Long id;
 
-  // title x
-
   @Column(nullable = false)
   private String content;
 
@@ -41,6 +42,10 @@ public class Question {
 
   @ManyToOne(fetch = FetchType.LAZY)
   private User userManager;
+
+  // question tag 양방향 매핑
+  @OneToMany(mappedBy = "question")
+  private List<QuestionTag> questionTagList = new ArrayList<>();
 
   public void likeUp(){
     this.bookmark_count++;

--- a/src/main/java/com/dnd10/iterview/entity/Question.java
+++ b/src/main/java/com/dnd10/iterview/entity/Question.java
@@ -54,4 +54,8 @@ public class Question {
   public void likeDown(){
     this.bookmark_count--;
   }
+
+  public void addTag(QuestionTag tag){
+    questionTagList.add(tag);
+  }
 }

--- a/src/main/java/com/dnd10/iterview/entity/QuestionTag.java
+++ b/src/main/java/com/dnd10/iterview/entity/QuestionTag.java
@@ -6,6 +6,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,7 +27,8 @@ public class QuestionTag {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  private Question questionManager;
+  @JoinColumn(name = "question_id")
+  private Question question;
 
   @ManyToOne(fetch = FetchType.LAZY)
   private Tag tagManager;

--- a/src/main/java/com/dnd10/iterview/repository/QuestionRepository.java
+++ b/src/main/java/com/dnd10/iterview/repository/QuestionRepository.java
@@ -1,10 +1,13 @@
 package com.dnd10.iterview.repository;
 
+import com.dnd10.iterview.entity.Question;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @Transactional(readOnly = true)
-public class QuestionRepository {
-
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+  Optional<Question> findById(Long id);
 }

--- a/src/main/java/com/dnd10/iterview/repository/QuestionRepository.java
+++ b/src/main/java/com/dnd10/iterview/repository/QuestionRepository.java
@@ -1,0 +1,10 @@
+package com.dnd10.iterview.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+public class QuestionRepository {
+
+}

--- a/src/main/java/com/dnd10/iterview/repository/QuestionTagRepository.java
+++ b/src/main/java/com/dnd10/iterview/repository/QuestionTagRepository.java
@@ -1,0 +1,12 @@
+package com.dnd10.iterview.repository;
+
+import com.dnd10.iterview.entity.QuestionTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+public interface QuestionTagRepository extends JpaRepository<QuestionTag, Long> {
+
+}

--- a/src/main/java/com/dnd10/iterview/repository/TagRepository.java
+++ b/src/main/java/com/dnd10/iterview/repository/TagRepository.java
@@ -1,0 +1,13 @@
+package com.dnd10.iterview.repository;
+
+import com.dnd10.iterview.entity.Tag;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+public interface TagRepository extends JpaRepository<Tag, Long> {
+  Optional<Tag> findByName(String name);
+}

--- a/src/main/java/com/dnd10/iterview/service/QuestionService.java
+++ b/src/main/java/com/dnd10/iterview/service/QuestionService.java
@@ -1,5 +1,16 @@
 package com.dnd10.iterview.service;
 
+import com.dnd10.iterview.dto.QuestionResponseDto;
+import com.dnd10.iterview.dto.QuestionTagResponseDto;
+import com.dnd10.iterview.dto.UserDto;
+import com.dnd10.iterview.entity.Question;
+import com.dnd10.iterview.entity.QuestionTag;
+import com.dnd10.iterview.repository.QuestionRepository;
+import com.dnd10.iterview.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javassist.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,4 +20,38 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class QuestionService {
 
+  QuestionRepository questionRepository;
+
+  public QuestionService(QuestionRepository questionRepository) {
+    this.questionRepository = questionRepository;
+  }
+
+  public QuestionResponseDto getQuestion(Long questionId){
+    // todo: db에서 못찾는 에러 발생중
+    Question question = questionRepository.findById(questionId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 문제가 존재하지 않습니다."));
+
+    return generateQuestionResponseDto(question);
+  }
+
+  private QuestionResponseDto generateQuestionResponseDto(Question question){
+    UserDto userDto = new UserDto(question.getUserManager());
+
+    List<QuestionTagResponseDto> dtoList = new ArrayList<>();
+    for(QuestionTag t : question.getQuestionTagList()){
+      QuestionTagResponseDto dto = QuestionTagResponseDto.builder()
+          .tagTitle(t.getTagManager().getName())
+          .build();
+
+      dtoList.add(dto);
+    }
+
+    return QuestionResponseDto.builder()
+        .content(question.getContent())
+        .create_date(question.getCreate_date())
+        .bookmark_count(question.getBookmark_count())
+        .user(userDto)
+        .tagList(dtoList)
+        .build();
+  }
 }

--- a/src/main/java/com/dnd10/iterview/service/QuestionService.java
+++ b/src/main/java/com/dnd10/iterview/service/QuestionService.java
@@ -1,17 +1,22 @@
 package com.dnd10.iterview.service;
 
+import com.dnd10.iterview.dto.QuestionRequestDto;
 import com.dnd10.iterview.dto.QuestionResponseDto;
 import com.dnd10.iterview.dto.QuestionTagResponseDto;
 import com.dnd10.iterview.dto.UserDto;
 import com.dnd10.iterview.entity.Question;
 import com.dnd10.iterview.entity.QuestionTag;
+import com.dnd10.iterview.entity.Tag;
+import com.dnd10.iterview.entity.User;
 import com.dnd10.iterview.repository.QuestionRepository;
+import com.dnd10.iterview.repository.QuestionTagRepository;
+import com.dnd10.iterview.repository.TagRepository;
 import com.dnd10.iterview.repository.UserRepository;
+import java.security.Principal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javassist.NotFoundException;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,9 +25,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuestionService {
 
   QuestionRepository questionRepository;
+  UserRepository userRepository;
+  TagRepository tagRepository;
+  QuestionTagRepository questionTagRepository;
 
-  public QuestionService(QuestionRepository questionRepository) {
+  public QuestionService(QuestionRepository questionRepository, UserRepository userRepository,
+      TagRepository tagRepository, QuestionTagRepository questionTagRepository) {
     this.questionRepository = questionRepository;
+    this.userRepository = userRepository;
+    this.tagRepository = tagRepository;
+    this.questionTagRepository = questionTagRepository;
   }
 
   public QuestionResponseDto getQuestion(Long questionId){
@@ -30,6 +42,50 @@ public class QuestionService {
         .orElseThrow(() -> new IllegalArgumentException("해당 문제가 존재하지 않습니다."));
 
     return generateQuestionResponseDto(question);
+  }
+
+  public QuestionResponseDto addQuestion(Principal principal, QuestionRequestDto requestDto){
+    User user = userRepository.findUserByEmail(principal.getName())
+        .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+
+    Question question = generateQuestion(user, requestDto);
+    Question saved = questionRepository.save(question);
+
+    return generateQuestionResponseDto(saved);
+  }
+
+  private Question generateQuestion(User user, QuestionRequestDto requestDto){
+    Question question = Question.builder()
+        .content(requestDto.getContent())
+        .bookmark_count(requestDto.getBookmark_count())
+        .create_date(LocalDate.now())
+        .userManager(user)
+        .questionTagList(new ArrayList<>())
+        .build();
+
+    Question saved = questionRepository.save(question);
+    generateTags(saved, requestDto.getTags());
+
+    return saved;
+  }
+
+  private void generateTags(Question question, String tags){
+
+    // todo: 어떤 구분자로 나눠서 줄지는 프론트와 이야기
+    String[] tagSplit = tags.split("/");
+    for(String s : tagSplit){
+      // 태그 미리 일부만 지정하기로 했으니 이외의 태그는 입력 못하도록
+      Tag tag = tagRepository.findByName(s)
+          .orElseThrow(() -> new IllegalArgumentException("해당 태그가 존재하지 않습니다."));
+
+      QuestionTag questionTag = QuestionTag.builder()
+          .question(question)
+          .tagManager(tag)
+          .build();
+
+      QuestionTag saved = questionTagRepository.save(questionTag);
+      question.addTag(saved); // 양방향 매핑
+    }
   }
 
   private QuestionResponseDto generateQuestionResponseDto(Question question){

--- a/src/main/java/com/dnd10/iterview/service/QuestionService.java
+++ b/src/main/java/com/dnd10/iterview/service/QuestionService.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
-@RequiredArgsConstructor
 public class QuestionService {
 
   QuestionRepository questionRepository;
@@ -27,7 +26,6 @@ public class QuestionService {
   }
 
   public QuestionResponseDto getQuestion(Long questionId){
-    // todo: db에서 못찾는 에러 발생중
     Question question = questionRepository.findById(questionId)
         .orElseThrow(() -> new IllegalArgumentException("해당 문제가 존재하지 않습니다."));
 

--- a/src/main/java/com/dnd10/iterview/service/QuestionService.java
+++ b/src/main/java/com/dnd10/iterview/service/QuestionService.java
@@ -60,6 +60,7 @@ public class QuestionService {
         .bookmark_count(requestDto.getBookmark_count())
         .create_date(LocalDate.now())
         .userManager(user)
+        // question entity에 리스트 객체 넣어서 안해도 될줄 알았는데 NPE 오류.. builder 관련 찾아보기
         .questionTagList(new ArrayList<>())
         .build();
 

--- a/src/main/java/com/dnd10/iterview/service/QuestionService.java
+++ b/src/main/java/com/dnd10/iterview/service/QuestionService.java
@@ -1,0 +1,12 @@
+package com.dnd10.iterview.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class QuestionService {
+
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,8 @@
+{
+  "properties": [
+    {
+      "name": "spring",
+      "type": "java.lang.String",
+      "description": "Description for spring."
+  }
+] }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,8 +1,0 @@
-{
-  "properties": [
-    {
-      "name": "spring",
-      "type": "java.lang.String",
-      "description": "Description for spring."
-  }
-] }


### PR DESCRIPTION
GET /api/v1/question/{questionId} : 해당 questionId의 문제 조회해서 반환.

POST /api/v1/question : 새로운 문제 정보를 questionRequestDto로 받아 문제 생성, 저장 후 저장된 question 반환

```
{
    "content": "hello",
    "bookmark_count": 1,
    "create_date": "2021-07-28",
    "user": {
        "email": "yeeunlee0520@gmail.com",
        "username": "룰루",
        "provider": "google",
        "providerId": "115780716502819759274"
    },
    "tagList": [
        {
            "tagTitle": "kakao"
        },
        {
            "tagTitle": "hello"
        }
    ]
}
```

일단은 상현님이 만든 userDto로 반환을 하는 상태인데, 이게 다른 유저가 만든 문제도 저렇게 보내도록 되어서 보안상 문제가 있을 것 같습니다.
이건 question용 유저 dto를 email, username만 있는걸로 따로 만들거나, 그냥 questionResponseDto에선 username만 반환하는것도 괜찮을거 같아요. 확인하고 수정하겠습니당.