### PR TITLE
fix: github 로그인 시 jwt 토큰 발행 못하는 에러 임시 수정

### DIFF
--- a/src/main/java/com/dnd10/iterview/config/oauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/dnd10/iterview/config/oauth2/CustomOAuth2SuccessHandler.java
@@ -39,12 +39,23 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
         DefaultOAuth2User principal = (DefaultOAuth2User) authentication.getPrincipal();
 
-        String jwtToken = JWT.create()
-                .withSubject(principal.getAttribute("sub"))
+        String jwtToken;
+        if(principal.getAttributes().containsKey("id")){
+            jwtToken = JWT.create()
+                .withSubject(Integer.toString(principal.getAttribute("id")))
                 .withExpiresAt(new Date(System.currentTimeMillis()+ jwtProperties.getExpirationTime()))
-                .withClaim("id", (Long) principal.getAttribute("id"))
+                //.withClaim("id", (Long) principal.getAttribute("id")) // todo: 필요한가? 없어도 동작 잘되는 것 확인
                 .withClaim("email", (String) principal.getAttribute("email"))
                 .sign(Algorithm.HMAC256(jwtProperties.getSecret()));
+        } // todo: github 임시. principal의 client~ 로 github, google 있는거 이용하려 했는데, 접근 불가능.
+        else {
+            jwtToken = JWT.create()
+                .withSubject(principal.getAttribute("sub"))
+                .withExpiresAt(
+                    new Date(System.currentTimeMillis() + jwtProperties.getExpirationTime()))
+                .withClaim("email", (String) principal.getAttribute("email"))
+                .sign(Algorithm.HMAC256(jwtProperties.getSecret()));
+        }
         response.addHeader(JwtProperties.HEADER_STRING, JwtProperties.TOKEN_PREFIX + jwtToken);
 
         final Cookie cookie = cookieUtils

--- a/src/main/java/com/dnd10/iterview/config/oauth2/GithubOAuth2Info.java
+++ b/src/main/java/com/dnd10/iterview/config/oauth2/GithubOAuth2Info.java
@@ -10,12 +10,12 @@ public class GithubOAuth2Info extends OAuth2UserInfo {
 
   @Override
   public String getId() {
-    return (String) attributes.get("sub");
+    return Integer.toString((int)attributes.get("id"));
   }
 
   @Override
   public String getName() {
-    return (String) attributes.get("name");
+    return (String) attributes.get("login");
   }
 
   @Override


### PR DESCRIPTION
일단 github랑 google이 반환하는 principal이 달라서 발생하는 부분은 수정했습니다.

근데 지금 문제가, github의 oauth2 user가 제공하는 email 정보가 굉장히 제한적이에요.
<img width="424" alt="c" src="https://user-images.githubusercontent.com/37532204/129905444-730285dc-bb33-471c-b9b1-4963c5f035bc.PNG">

여기서 저기 public email이 등록되어 있지 않으면 이메일을 못가져옵니다..
로그인 시의 이메일은 못가져오는지 좀 찾아봤는데... 따로 깃허브 측한테 request를 날려야 되는거 같아요.
https://stackoverflow.com/questions/35373995/github-user-email-is-null-despite-useremail-scope

이런 요청을 스프링 시큐리티 내에서 어케 보낼지 잘 모르겠어서 일단.. 등록되어 있을 시 로그인 잘 되는 것 확인했습니다.

그리고 jwt 토큰 보낼때 이전에 subject 말고 claim으로 id를 한번 더 넣었는데, 이게 자꾸 github 쪽에서 에러가 나기도 하고, 이미 식별할 이메일 정보를 넣었는데 id를 또 넣을 필요성이 없을거 같아서 일단 제거해봤습니다.

원래 github랑 google이랑 구분은 client 쪽 string으로 구분하는게 가장 좋긴 한데, principal의 google이나 github 스트링을 못가져와서 일단 "id" 여부로 판단합니다.. 

조금 야매스럽게... 에러를 수정한거 같긴 한데, 아직은 이 방법 말고는 안 떠오르네요..